### PR TITLE
Add desktop system notifications support

### DIFF
--- a/demo_themes.md
+++ b/demo_themes.md
@@ -6,8 +6,9 @@
 - **Smart Detection**: Automatically detects when new articles are published
 - **Persistent Tracking**: Remembers which articles you've seen across app restarts  
 - **Configurable**: Enable/disable notifications in the settings
-- **Lightweight**: Non-intrusive banner that appears when new content is available
-- **Easy Dismissal**: Press Space, Enter, or 'n' to dismiss notifications
+- **Dual Notifications**: Shows both in-app banners AND system notifications
+- **Cross-Platform**: Uses `notify-send` on Linux, falls back gracefully on other systems
+- **Easy Dismissal**: Press Space, Enter, or 'n' to dismiss in-app notifications
 
 ### 🎨 New Color Themes
 - **default**: Modern indigo and pink theme with clean styling
@@ -81,8 +82,11 @@ The notification system creates these files in `~/.config/rsss/`:
 
 ### 🔔 **How Notifications Work**
 1. **First Run**: All current articles are marked as "seen" without notification
-2. **Subsequent Runs**: New articles trigger a notification banner
-3. **Persistence**: Article tracking survives app restarts
-4. **Smart Refresh**: Only shows notifications for truly new content
+2. **Subsequent Runs**: New articles trigger both system and in-app notifications
+3. **System Notifications**: Appears in your desktop notification center (Linux with `notify-send`)
+4. **In-App Notifications**: Shows a banner within the TUI interface
+5. **Persistence**: Article tracking survives app restarts
+6. **Smart Refresh**: Only shows notifications for truly new content
+7. **Requirements**: On Linux, ensure `libnotify` is installed (`pacman -S libnotify` on Arch)
 
 All existing functionality remains the same, but with a much more polished interface and intelligent new article notifications!

--- a/pkg/notifications/notifications.go
+++ b/pkg/notifications/notifications.go
@@ -1,0 +1,62 @@
+package notifications
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+)
+
+// Notifier interface for different notification systems
+type Notifier interface {
+	Send(title, message string) error
+}
+
+// LinuxNotifier uses notify-send for Linux systems
+type LinuxNotifier struct{}
+
+// Send sends a notification using notify-send
+func (n *LinuxNotifier) Send(title, message string) error {
+	cmd := exec.Command("notify-send", 
+		"--app-name=RSSS",
+		"--icon=rss",
+		"--urgency=normal",
+		title, 
+		message)
+	return cmd.Run()
+}
+
+// NoOpNotifier does nothing (fallback for unsupported systems)
+type NoOpNotifier struct{}
+
+func (n *NoOpNotifier) Send(title, message string) error {
+	return nil
+}
+
+// NewNotifier creates a new notifier based on the operating system
+func NewNotifier() Notifier {
+	switch runtime.GOOS {
+	case "linux":
+		// Check if notify-send is available
+		if _, err := exec.LookPath("notify-send"); err == nil {
+			return &LinuxNotifier{}
+		}
+		fallthrough
+	default:
+		return &NoOpNotifier{}
+	}
+}
+
+// SendArticleNotification sends a notification about new articles
+func SendArticleNotification(notifier Notifier, count int) error {
+	var title, message string
+	
+	if count == 1 {
+		title = "RSSS - New Article"
+		message = "1 new article available!"
+	} else {
+		title = "RSSS - New Articles"
+		message = fmt.Sprintf("%d new articles available!", count)
+	}
+	
+	return notifier.Send(title, message)
+}

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"rsss/pkg/config"
+	"rsss/pkg/notifications"
 	"rsss/pkg/rss"
 )
 
@@ -41,10 +42,11 @@ type Model struct {
 	ViewportTop  int // For scrolling in feed view
 	
 	// Notification system
-	SeenArticles    map[string]bool // Track seen article URLs
-	NewArticleCount int             // Count of new articles since last check
-	ShowNotification bool           // Whether to show notification
-	NotificationMsg  string         // Notification message to display
+	SeenArticles    map[string]bool          // Track seen article URLs
+	NewArticleCount int                      // Count of new articles since last check
+	ShowNotification bool                    // Whether to show notification
+	NotificationMsg  string                  // Notification message to display
+	SystemNotifier  notifications.Notifier  // System notification handler
 }
 
 // NewModel creates a new TUI model
@@ -70,6 +72,7 @@ func NewModel(cfg *config.Config, feeds *config.FeedConfig, rssClient *rss.Clien
 		SeenArticles:     seenArticles,
 		NewArticleCount:  0,
 		ShowNotification: false,
+		SystemNotifier:   notifications.NewNotifier(),
 	}
 }
 
@@ -145,6 +148,10 @@ func (m *Model) checkForNewArticles(articles []rss.Article) {
 		} else {
 			m.NotificationMsg = fmt.Sprintf("🔔 %d new articles available!", newCount)
 		}
+		
+		// Send system notification
+		notifications.SendArticleNotification(m.SystemNotifier, newCount)
+		
 		m.saveSeenArticles()
 	} else if newCount > 0 {
 		// Still save seen articles even if notifications are disabled


### PR DESCRIPTION
- Create notifications package with Linux notify-send integration
- Add SystemNotifier to TUI model for cross-platform support
- Send both in-app and desktop notifications for new articles
- Graceful fallback for systems without notify-send
- Update documentation with system notification details
- Requires libnotify on Linux systems for desktop notifications